### PR TITLE
Ensure npm available for Pages action

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -53,6 +53,10 @@ jobs:
         with:
           node-version: "20"
           cache: ${{ steps.detect-package-manager.outputs.manager }}
+      - name: Ensure npm
+        run: |
+          corepack enable
+          corepack prepare npm@latest --activate
       - name: Setup Pages
         uses: actions/configure-pages@v5
         with:


### PR DESCRIPTION
## Summary
- enable npm via corepack before configuring GitHub Pages

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ab0b740c20832a9d9da632b0a0c77c