### PR TITLE
Enable Pages with PAT and ensure npm availability

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -53,9 +53,15 @@ jobs:
         with:
           node-version: "20"
           cache: ${{ steps.detect-package-manager.outputs.manager }}
+      - name: Ensure npm
+        run: |
+          corepack enable
+          corepack prepare npm@latest --activate
       - name: Setup Pages
         uses: actions/configure-pages@v5
         with:
+          token: ${{ secrets.PAGES_TOKEN }}
+          enablement: true
           # Automatically inject basePath in your Next.js configuration file and disable
           # server side image optimization (https://nextjs.org/docs/api-reference/next/image#unoptimized).
           #


### PR DESCRIPTION
## Summary
- use `PAGES_TOKEN` secret so configure-pages can create the Pages site
- enable npm via corepack before configuring GitHub Pages

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ab0b740c20832a9d9da632b0a0c77c