### PR TITLE
Add hero call-to-action linking to events section

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -145,6 +145,14 @@ img { max-width: 100%; height: auto; display: block; }
   font-size: 18px;
 }
 
+.hero .actions {
+  animation: fadeSlideDown 0.8s ease both;
+  animation-delay: 0.4s;
+  position: relative;
+  z-index: 1;
+  justify-content: center;
+}
+
 .hero-orb {
   position: absolute;
   border-radius: 50%;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,5 @@
 import { Suspense } from 'react';
+import Link from 'next/link';
 import { getAllEventsMeta } from '@/lib/content';
 import EventsList from './events/EventsList';
 
@@ -16,10 +17,17 @@ export default function Page() {
         <p className="home-intro hero-intro">
           국내 주짓수 대회를 한 번에 확인하세요.
         </p>
+        <div className="actions">
+          <Link href="#events" className="btn btn-primary">
+            대회 보기
+          </Link>
+        </div>
       </section>
-      <Suspense>
-        <EventsList events={events} />
-      </Suspense>
+      <section id="events">
+        <Suspense>
+          <EventsList events={events} />
+        </Suspense>
+      </section>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add call-to-action button in hero to scroll to events section
- style hero action for centered animation

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b1d7498310832a853702a5a58a42e0