### PR TITLE
feat: add Noto Sans KR font globally

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -10,7 +10,6 @@ html { scroll-behavior: smooth; }
   --primary: #111;
 }
 body {
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Arial, "Apple SD Gothic Neo", "Noto Sans KR", sans-serif;
   color: var(--text);
   background: var(--bg);
   line-height: 1.6;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,11 @@
 import './globals.css';
+import { Noto_Sans_KR } from 'next/font/google';
 import Link from 'next/link';
 import FancyCursor from '@/components/FancyCursor';
+
+const notoSans = Noto_Sans_KR({
+  subsets: ['latin'],
+});
 
 export const metadata = {
   title: 'BJJ 대회 일정',
@@ -10,7 +15,7 @@ export const metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="ko">
-      <body>
+      <body className={notoSans.className}>
         <FancyCursor />
         <a href="#main" className="skip-link">본문 바로가기</a>
         <header className="header">


### PR DESCRIPTION
## Summary
- import and apply Noto Sans KR font globally via `next/font`
- remove manual font stack from global styles

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b1d7414e48832a83cf5ca0ffe06595