### PR TITLE
feat: add region filter for events

### DIFF
--- a/app/events/EventsList.tsx
+++ b/app/events/EventsList.tsx
@@ -3,6 +3,7 @@
 import Link from 'next/link';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useRef, type KeyboardEvent } from 'react';
+import RegionFilter from './RegionFilter';
 import type { EventMeta } from '@/lib/content';
 
 const TABS = [
@@ -22,12 +23,14 @@ export default function EventsList({
   const searchParams = useSearchParams();
   const router = useRouter();
   const tag = searchParams.get('tag') || undefined;
+  const region = searchParams.get('region') || undefined;
   const currentIndex = Math.max(
     0,
     TABS.findIndex(t => t.key === tag),
   );
   const tabRefs = useRef<(HTMLButtonElement | null)[]>([]);
-  const filtered = tag ? events.filter(e => e.tags?.includes(tag)) : events;
+  let filtered = tag ? events.filter(e => e.tags?.includes(tag)) : events;
+  filtered = region ? filtered.filter(e => e.city === region) : filtered;
   const items = filtered;
   const counts = TABS.map(({ key }) =>
     key ? events.filter(e => e.tags?.includes(key)).length : events.length,
@@ -35,7 +38,13 @@ export default function EventsList({
 
   const selectTab = (idx: number) => {
     const { key } = TABS[idx];
-    router.push(key ? `${basePath}?tag=${key}` : basePath);
+    const params = new URLSearchParams(Array.from(searchParams.entries()));
+    if (key) {
+      params.set('tag', key);
+    } else {
+      params.delete('tag');
+    }
+    router.push(`${basePath}?${params.toString()}`);
   };
 
   const handleKeyDown = (
@@ -55,6 +64,7 @@ export default function EventsList({
 
   return (
     <>
+      <RegionFilter events={events} basePath={basePath} />
       <div className="tabs" role="tablist">
         {TABS.map(({ key, label }, idx) => (
           <button

--- a/app/events/RegionFilter.tsx
+++ b/app/events/RegionFilter.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useMemo } from 'react';
+import type { EventMeta } from '@/lib/content';
+
+export default function RegionFilter({
+  events,
+  basePath = '/',
+}: {
+  events: EventMeta[];
+  basePath?: string;
+}) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const region = searchParams.get('region') || '';
+
+  const regions = useMemo(() => {
+    const set = new Set<string>();
+    events.forEach(e => {
+      if (e.city) set.add(e.city);
+    });
+    return Array.from(set).sort();
+  }, [events]);
+
+  const updateRegion = (value: string) => {
+    const params = new URLSearchParams(Array.from(searchParams.entries()));
+    if (value) {
+      params.set('region', value);
+    } else {
+      params.delete('region');
+    }
+    const query = params.toString();
+    router.push(`${basePath}${query ? `?${query}` : ''}`);
+  };
+
+  return (
+    <div className="region-filter">
+      <select
+        aria-label="지역 선택"
+        value={region}
+        onChange={e => updateRegion(e.target.value)}
+      >
+        <option value="">전체 지역</option>
+        {regions.map(r => (
+          <option key={r} value={r}>
+            {r}
+          </option>
+        ))}
+      </select>
+      {region && (
+        <div className="selected-region">
+          <span className="badge">
+            {region}
+            <button
+              type="button"
+              aria-label="지역 제거"
+              onClick={() => updateRegion('')}
+              className="ml-1"
+            >
+              ×
+            </button>
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- integrate dropdown-based region filter into events list
- add client region filter component

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b1e7462c20832a9e5c5efb1ab28c95