### PR TITLE
Build event tabs dynamically from event tags

### DIFF
--- a/app/events/EventsList.tsx
+++ b/app/events/EventsList.tsx
@@ -6,13 +6,6 @@ import { useRef, type KeyboardEvent } from 'react';
 import RegionFilter from './RegionFilter';
 import type { EventMeta } from '@/lib/content';
 
-const TABS = [
-  { key: undefined, label: '전체' },
-  { key: 'kbjjf', label: 'KBJJF' },
-  { key: 'street', label: '스트릿 주짓수' },
-  { key: 'jagers', label: '예거스' },
-];
-
 export default function EventsList({
   events,
   basePath = '/',
@@ -25,12 +18,20 @@ export default function EventsList({
   const tag = searchParams.get('tag') || undefined;
   const region = searchParams.get('region') || undefined;
   const showPast = searchParams.get('past') === '1';
+
+  const tags = Array.from(
+    new Set(events.flatMap(e => e.tags ?? [])),
+  );
+  const tabs = [
+    { key: undefined, label: '전체' },
+    ...tags.map(t => ({ key: t, label: t })),
+  ];
+
   const currentIndex = Math.max(
     0,
-    TABS.findIndex(t => t.key === tag),
+    tabs.findIndex(t => t.key === tag),
   );
   const tabRefs = useRef<(HTMLButtonElement | null)[]>([]);
-
 
   const today = new Date();
   today.setHours(0, 0, 0, 0);
@@ -42,7 +43,7 @@ export default function EventsList({
     ? dateFiltered.filter(e => e.city === region)
     : dateFiltered;
 
-  const counts = TABS.map(({ key }) =>
+  const counts = tabs.map(({ key }) =>
     key
       ? regionFiltered.filter(e => e.tags?.includes(key)).length
       : regionFiltered.length,
@@ -63,7 +64,7 @@ export default function EventsList({
   };
 
   const selectTab = (idx: number) => {
-    const { key } = TABS[idx];
+    const { key } = tabs[idx];
     const params = new URLSearchParams(Array.from(searchParams.entries()));
     if (key) {
       params.set('tag', key);
@@ -81,8 +82,8 @@ export default function EventsList({
       e.preventDefault();
       const nextIndex =
         e.key === 'ArrowRight'
-          ? (idx + 1) % TABS.length
-          : (idx - 1 + TABS.length) % TABS.length;
+          ? (idx + 1) % tabs.length
+          : (idx - 1 + tabs.length) % tabs.length;
       const nextTab = tabRefs.current[nextIndex];
       if (nextTab) {
         nextTab.focus();
@@ -105,7 +106,7 @@ export default function EventsList({
         </label>
       </div>
       <div className="tabs" role="tablist">
-        {TABS.map(({ key, label }, idx) => (
+        {tabs.map(({ key, label }, idx) => (
           <button
             key={key ?? 'all'}
             ref={el => {


### PR DESCRIPTION
## Summary
- Collect unique tags from event data and build tabs array dynamically with "전체" prepended
- Update tab selection, counting, and navigation logic to use the dynamic tabs list

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b463a0638c832a9283bfeaf61771c6