### PR TITLE
feat: add Adsense banner

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -28,6 +28,7 @@ body {
   color: var(--text);
   background: var(--bg);
   line-height: 1.6;
+  padding-bottom: 80px;
 }
 a { color: inherit; text-decoration: none; }
 img { max-width: 100%; height: auto; display: block; }
@@ -80,6 +81,18 @@ img { max-width: 100%; height: auto; display: block; }
   background: var(--muted);
 }
 .footer { border-top: 1px solid var(--border); padding: 24px 0; color: var(--muted); font-size: 14px; margin-top: 40px; }
+
+.ad-banner {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  background: var(--surface);
+  border-top: 1px solid var(--border);
+  display: flex;
+  justify-content: center;
+  z-index: 20;
+}
 
 .grid { display: grid; grid-template-columns: repeat(1, 1fr); gap: 16px; }
 @media (min-width: 720px) {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,9 +1,11 @@
 import './globals.css';
 import { Noto_Sans_KR } from 'next/font/google';
 import Link from 'next/link';
+import Script from 'next/script';
 import FancyCursor from '@/components/FancyCursor';
 import CursorToggle from '@/components/CursorToggle';
 import ThemeToggle from '@/components/ThemeToggle';
+import AdBanner from '@/components/AdBanner';
 
 const notoSans = Noto_Sans_KR({
   subsets: ['latin'],
@@ -18,6 +20,12 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="ko">
       <body className={notoSans.className}>
+        <Script
+          async
+          src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-2370970936034063"
+          crossOrigin="anonymous"
+          strategy="afterInteractive"
+        />
         <FancyCursor />
         <a href="#main" className="skip-link">본문 바로가기</a>
         <header className="header">
@@ -40,6 +48,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <Link href="/rules" className="rulebook-tab">
           룰 북 보러가기!
         </Link>
+        <AdBanner />
       </body>
     </html>
   );

--- a/components/AdBanner.tsx
+++ b/components/AdBanner.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import { useEffect } from 'react';
+
+declare global {
+  interface Window {
+    adsbygoogle?: { [key: string]: unknown }[];
+  }
+}
+
+export default function AdBanner() {
+  useEffect(() => {
+    try {
+      window.adsbygoogle = window.adsbygoogle || [];
+      window.adsbygoogle.push({});
+    } catch (err) {
+      console.error(err);
+    }
+  }, []);
+
+  return (
+    <div className="ad-banner">
+      <ins
+        className="adsbygoogle"
+        style={{ display: 'block' }}
+        data-ad-client="ca-pub-2370970936034063"
+        data-ad-slot="1234567890"
+        data-ad-format="auto"
+        data-full-width-responsive="true"
+      ></ins>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- integrate Google AdSense script and banner component to display ads
- style fixed bottom ad banner and add body padding

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c44610382c832a84f2d0c634944114