### PR TITLE
Add closing events page and urgent navigation button

### DIFF
--- a/app/events/closing/page.tsx
+++ b/app/events/closing/page.tsx
@@ -1,0 +1,48 @@
+import Link from 'next/link';
+import { getAllEventsMeta } from '@/lib/content';
+
+export const metadata = { title: '얼마 남지 않은 대회 일정' };
+
+export default function ClosingEventsPage() {
+  const items = getAllEventsMeta();
+  const today = new Date();
+  today.setHours(0,0,0,0);
+  const soon = new Date(today);
+  soon.setDate(today.getDate() + 14);
+  const closing = items
+    .filter(e => {
+      const d = new Date(e.date);
+      return d >= today && d <= soon;
+    })
+    .sort((a,b) => new Date(a.date).getTime() - new Date(b.date).getTime());
+
+  return (
+    <div>
+      <h1>얼마 남지 않은 대회 일정</h1>
+      {closing.length === 0 ? (
+        <p>현재 곧 개최되는 대회가 없습니다.</p>
+      ) : (
+        <div className="grid">
+          {closing.map(e => (
+            <div key={e.slug} className="card">
+              <h3 style={{ margin: '8px 0' }}>
+                <Link href={`/events/${e.slug}/`}>{e.title}</Link>
+              </h3>
+              <div className="small">
+                {new Date(e.date).toLocaleDateString('ko-KR')} · {e.city} {e.venue ? `· ${e.venue}` : ''}
+              </div>
+              <div style={{ marginTop: 8 }}>{e.excerpt}</div>
+              {e.registrationUrl ? (
+                <div style={{ marginTop: 8 }}>
+                  <a href={e.registrationUrl} target="_blank" rel="noopener noreferrer">
+                    접수 링크 바로가기
+                  </a>
+                </div>
+              ) : null}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -523,6 +523,11 @@ img { max-width: 100%; height: auto; display: block; }
   background: linear-gradient(135deg, #6366f1, #ec4899);
   color: #fff;
 }
+.btn-urgent {
+  background: linear-gradient(135deg, #ef4444, #f97316);
+  color: #fff;
+  animation: pulse 2s infinite;
+}
 .btn-outline {
   border: 2px solid var(--primary);
   color: var(--primary);

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -22,6 +22,9 @@ export default function Page() {
           <Link href="#events" className="btn btn-primary">
             대회 보기
           </Link>
+          <Link href="/events/closing" className="btn btn-urgent">
+            얼마 남지 않은 대회
+          </Link>
         </div>
       </section>
       <section id="events">


### PR DESCRIPTION
## Summary
- add dedicated page showing events happening within the next two weeks
- introduce pulsating orange button style and link from home hero

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68c6935afdf8832a84959e01696e8525