### PR TITLE
Add Street Jiujitsu autumn open events

### DIFF
--- a/content/events/2025-09-21-gumi-open.md
+++ b/content/events/2025-09-21-gumi-open.md
@@ -1,12 +1,12 @@
 ---
-title: "스트릿 주짓수 123 구미 오픈"
+title: "스트릿 주짓수 구미 오픈"
 date: "2025-09-21"
 city: "구미"
-venue: "박정희체육관"
+venue: "박정희체육관 (경상북도 구미시 박정희로 375-19)"
 organizer: "Street Jiujitsu"
 tags: ["gi","nogi","street"]
-registrationUrl: "https://www.street-jiujitsu.com/%EB%B3%B5%EC%A0%9C-%EC%8A%A4%ED%8A%B8%EB%A6%BF121-%EC%84%9C%EC%9A%B8-%EC%98%A4%ED%94%88"
-sourceUrl: "https://www.street-jiujitsu.com/%EB%B3%B5%EC%A0%9C-%EC%8A%A4%ED%8A%B8%EB%A6%BF121-%EC%84%9C%EC%9A%B8-%EC%98%A4%ED%94%88"
+registrationUrl: "https://www.street-jiujitsu.com/"
+sourceUrl: "https://www.street-jiujitsu.com/"
 ---
 
-> 공식 페이지 공지.
+> 스트릿 주짓수 오픈 시리즈, 구미 개최. Gi/Nogi 진행.

--- a/content/events/2025-09-28-bucheon-open.md
+++ b/content/events/2025-09-28-bucheon-open.md
@@ -1,0 +1,12 @@
+---
+title: "스트릿 주짓수 부천 오픈"
+date: "2025-09-28"
+city: "부천"
+venue: "송내사회체육관 (경기도 부천시 경인로 120번길 45)"
+organizer: "Street Jiujitsu"
+tags: ["gi","nogi","street"]
+registrationUrl: "https://www.street-jiujitsu.com/"
+sourceUrl: "https://www.street-jiujitsu.com/"
+---
+
+> 스트릿 주짓수 오픈 시리즈, 부천 개최. Gi/Nogi 진행.

--- a/content/events/2025-10-04-gimpo-open.md
+++ b/content/events/2025-10-04-gimpo-open.md
@@ -1,0 +1,12 @@
+---
+title: "스트릿 주짓수 김포 오픈"
+date: "2025-10-04"
+city: "김포"
+venue: "김포시민회관체육관 (경기도 김포시 사우중로 26)"
+organizer: "Street Jiujitsu"
+tags: ["gi","nogi","street"]
+registrationUrl: "https://www.street-jiujitsu.com/"
+sourceUrl: "https://www.street-jiujitsu.com/"
+---
+
+> 스트릿 주짓수 오픈 시리즈, 김포 개최. Gi/Nogi 진행.

--- a/content/events/2025-10-18-suwon-open.md
+++ b/content/events/2025-10-18-suwon-open.md
@@ -1,0 +1,12 @@
+---
+title: "스트릿 주짓수 126 수원 오픈"
+date: "2025-10-18"
+city: "수원"
+venue: "경기도인재개발원 체육관 (경기도 수원시 경수대로 1150)"
+organizer: "Street Jiujitsu"
+tags: ["gi","nogi","street"]
+registrationUrl: "https://www.street-jiujitsu.com/"
+sourceUrl: "https://www.street-jiujitsu.com/"
+---
+
+> 스트릿 주짓수 ‘126 수원 오픈’. Gi/Nogi 진행.

--- a/content/events/2025-10-19-incheon-open.md
+++ b/content/events/2025-10-19-incheon-open.md
@@ -1,0 +1,12 @@
+---
+title: "스트릿 주짓수 인천 오픈"
+date: "2025-10-19"
+city: "인천"
+venue: "올림픽기념국민생활관 체육관 (인천광역시 구월로 251)"
+organizer: "Street Jiujitsu"
+tags: ["gi","nogi","street"]
+registrationUrl: "https://www.street-jiujitsu.com/"
+sourceUrl: "https://www.street-jiujitsu.com/"
+---
+
+> 스트릿 주짓수 오픈 시리즈, 인천 개최. Gi/Nogi 진행.

--- a/content/events/2025-10-25-daegu-open.md
+++ b/content/events/2025-10-25-daegu-open.md
@@ -1,0 +1,12 @@
+---
+title: "스트릿 주짓수 대구 오픈"
+date: "2025-10-25"
+city: "대구"
+venue: "대구텍스타일콤플렉스 (대구광역시 동구 팔공로 227)"
+organizer: "Street Jiujitsu"
+tags: ["gi","nogi","street"]
+registrationUrl: "https://www.street-jiujitsu.com/"
+sourceUrl: "https://www.street-jiujitsu.com/"
+---
+
+> 스트릿 주짓수 오픈 시리즈, 대구 개최. Gi/Nogi 진행.

--- a/content/events/2025-10-26-jinju-open.md
+++ b/content/events/2025-10-26-jinju-open.md
@@ -1,0 +1,12 @@
+---
+title: "스트릿 주짓수 진주 오픈"
+date: "2025-10-26"
+city: "진주"
+venue: "문산실내체육관 (경상남도 진주시 문산읍 월아산로 973)"
+organizer: "Street Jiujitsu"
+tags: ["gi","nogi","street"]
+registrationUrl: "https://www.street-jiujitsu.com/"
+sourceUrl: "https://www.street-jiujitsu.com/"
+---
+
+> 스트릿 주짓수 오픈 시리즈, 진주 개최. Gi/Nogi 진행.


### PR DESCRIPTION
## Summary
- add Street Jiujitsu event pages for Gumi, Bucheon, Gimpo, Suwon, Incheon, Daegu and Jinju

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c68e3671d0832ab5448fb4879aa40f