### PR TITLE
feat: add month filter component

### DIFF
--- a/app/events/EventsList.tsx
+++ b/app/events/EventsList.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useRef, useState, useEffect, type KeyboardEvent } from 'react';
 import RegionFilter from './RegionFilter';
+import MonthFilter from './MonthFilter';
 import type { EventMeta } from '@/lib/content';
 
 interface Tab {
@@ -49,15 +50,6 @@ export default function EventsList({
   const dateFiltered = showPast
     ? events
     : events.filter(e => new Date(e.date) >= today);
-
-  const months = Array.from(
-    new Set(dateFiltered.map(e => e.date.slice(0, 7))),
-  ).sort();
-
-  const formatMonth = (m: string) => {
-    const [year, month] = m.split('-');
-    return `${year}년 ${Number(month)}월`;
-  };
 
   const regionFiltered = region
     ? dateFiltered.filter(e => e.city === region)
@@ -135,16 +127,6 @@ export default function EventsList({
     ? searchFiltered.filter(e => e.tags?.includes(tag))
     : searchFiltered;
 
-  const changeMonth = (value: string) => {
-    const params = new URLSearchParams(Array.from(searchParams.entries()));
-    if (value) {
-      params.set('month', value);
-    } else {
-      params.delete('month');
-    }
-    router.push(`${basePath}?${params.toString()}`);
-  };
-
   const togglePast = (checked: boolean) => {
     const params = new URLSearchParams(Array.from(searchParams.entries()));
     if (checked) {
@@ -196,19 +178,11 @@ export default function EventsList({
           aria-label="대회 검색"
         />
         <RegionFilter events={dateFiltered} basePath={basePath} />
-        <select
-          className="month-filter"
-          value={month}
-          onChange={e => changeMonth(e.target.value)}
-          aria-label="월별 검색"
-        >
-          <option value="">전체 월</option>
-          {months.map(m => (
-            <option key={m} value={m}>
-              {formatMonth(m)}
-            </option>
-          ))}
-        </select>
+        <MonthFilter
+          events={events}
+          available={dateFiltered}
+          basePath={basePath}
+        />
         <label className="past-toggle">
           <input
             type="checkbox"

--- a/app/events/MonthFilter.tsx
+++ b/app/events/MonthFilter.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import { useMemo } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import type { EventMeta } from '@/lib/content';
+
+interface Props {
+  events: EventMeta[];
+  available: EventMeta[];
+  basePath?: string;
+}
+
+export default function MonthFilter({ events, available, basePath = '/' }: Props) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const selected = searchParams.get('month') || '';
+
+  const months = useMemo(() => {
+    if (events.length === 0) return [];
+    const sorted = events.map(e => e.date.slice(0, 7)).sort();
+    const start = sorted[0];
+    const end = sorted[sorted.length - 1];
+    const [startY, startM] = start.split('-').map(Number);
+    const [endY, endM] = end.split('-').map(Number);
+    const result: string[] = [];
+    let y = startY;
+    let m = startM;
+    while (y < endY || (y === endY && m <= endM)) {
+      result.push(`${y}-${String(m).padStart(2, '0')}`);
+      m += 1;
+      if (m > 12) {
+        m = 1;
+        y += 1;
+      }
+    }
+    return result;
+  }, [events]);
+
+  const changeMonth = (value: string) => {
+    const params = new URLSearchParams(Array.from(searchParams.entries()));
+    if (value) {
+      params.set('month', value);
+    } else {
+      params.delete('month');
+    }
+    const query = params.toString();
+    router.push(`${basePath}${query ? `?${query}` : ''}`);
+  };
+
+  const formatMonth = (value: string) => {
+    const [year, month] = value.split('-');
+    return `${year}년 ${Number(month)}월`;
+  };
+
+  return (
+    <div className="month-filter">
+      <button
+        type="button"
+        className={`month-option${selected === '' ? ' active' : ''}`}
+        onClick={() => changeMonth('')}
+      >
+        전체
+      </button>
+      {months.map(m => {
+        const disabled = !available.some(e => e.date.startsWith(m));
+        return (
+          <button
+            key={m}
+            type="button"
+            className={`month-option${selected === m ? ' active' : ''}`}
+            onClick={() => changeMonth(m)}
+            disabled={disabled}
+          >
+            {formatMonth(m)}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+

--- a/app/globals.css
+++ b/app/globals.css
@@ -368,13 +368,31 @@ img { max-width: 100%; height: auto; display: block; }
   margin-bottom: 0;
 }
 .filters .month-filter {
-  margin-bottom: 16px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-bottom: 0;
+}
+
+.filters .month-filter .month-option {
   padding: 4px 8px;
   border: 1px solid var(--border);
   border-radius: 6px;
   background: var(--surface);
   color: var(--text);
   font-size: 14px;
+  cursor: pointer;
+}
+
+.filters .month-filter .month-option.active {
+  background: var(--primary);
+  color: var(--bg);
+  border-color: var(--primary);
+}
+
+.filters .month-filter .month-option:disabled {
+  opacity: 0.4;
+  cursor: default;
 }
 .filters .past-toggle {
   margin: 0;


### PR DESCRIPTION
## Summary
- add reusable month filter for events
- show months dynamically and disable empty months
- style month selector buttons

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c6a3777694832a8af9790fad9df804