### PR TITLE
Improve event list filtering readability

### DIFF
--- a/app/events/MonthFilter.tsx
+++ b/app/events/MonthFilter.tsx
@@ -15,6 +15,7 @@ export default function MonthFilter({ events, available, basePath = '/' }: Props
   const searchParams = useSearchParams();
   const selected = searchParams.get('month') || '';
 
+  /** 전체 이벤트에서 월 단위 타임라인을 생성한다. */
   const months = useMemo(() => {
     if (events.length === 0) return [];
     const sorted = events.map(e => e.date.slice(0, 7)).sort();
@@ -36,6 +37,7 @@ export default function MonthFilter({ events, available, basePath = '/' }: Props
     return result;
   }, [events]);
 
+  /** 월 버튼을 클릭했을 때 URL 쿼리 파라미터를 갱신한다. */
   const changeMonth = (value: string) => {
     const params = new URLSearchParams(Array.from(searchParams.entries()));
     if (value) {

--- a/app/events/closing/page.tsx
+++ b/app/events/closing/page.tsx
@@ -6,35 +6,44 @@ export const metadata = { title: '얼마 남지 않은 대회 일정' };
 export default function ClosingEventsPage() {
   const items = getAllEventsMeta();
   const today = new Date();
-  today.setHours(0,0,0,0);
+  today.setHours(0, 0, 0, 0);
   const soon = new Date(today);
   soon.setDate(today.getDate() + 14);
-  const closing = items
-    .filter(e => {
-      const d = new Date(e.date);
-      return d >= today && d <= soon;
+  // 2주 이내에 열리는 이벤트만 추려낸다.
+  const closingEvents = items
+    .filter(event => {
+      const date = new Date(event.date);
+      return date >= today && date <= soon;
     })
-    .sort((a,b) => new Date(a.date).getTime() - new Date(b.date).getTime());
+    .sort(
+      (a, b) => new Date(a.date).getTime() - new Date(b.date).getTime(),
+    );
 
   return (
     <div>
       <h1>얼마 남지 않은 대회 일정</h1>
-      {closing.length === 0 ? (
+      {closingEvents.length === 0 ? (
         <p>현재 곧 개최되는 대회가 없습니다.</p>
       ) : (
         <div className="grid">
-          {closing.map(e => (
-            <div key={e.slug} className="card">
+          {closingEvents.map(event => (
+            <div key={event.slug} className="card">
               <h3 style={{ margin: '8px 0' }}>
-                <Link href={`/events/${e.slug}/`}>{e.title}</Link>
+                <Link href={`/events/${event.slug}/`}>{event.title}</Link>
               </h3>
               <div className="small">
-                {new Date(e.date).toLocaleDateString('ko-KR')} · {e.city} {e.venue ? `· ${e.venue}` : ''}
+                {new Date(event.date).toLocaleDateString('ko-KR')}
+                {event.city ? ` · ${event.city}` : ''}
+                {event.venue ? ` · ${event.venue}` : ''}
               </div>
-              <div style={{ marginTop: 8 }}>{e.excerpt}</div>
-              {e.registrationUrl ? (
+              <div style={{ marginTop: 8 }}>{event.excerpt}</div>
+              {event.registrationUrl ? (
                 <div style={{ marginTop: 8 }}>
-                  <a href={e.registrationUrl} target="_blank" rel="noopener noreferrer">
+                  <a
+                    href={event.registrationUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
                     접수 링크 바로가기
                   </a>
                 </div>


### PR DESCRIPTION
## Summary
- refactor the events list component to memoize each filter stage and document the filter controls
- harden the region filter dropdown by guarding stored data parsing and add comments for keyboard/mouse flows
- add descriptive comments to the month filter and closing events page for easier future maintenance

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c92cd12aa4832a846e51b600908c0a