### PR TITLE
Add ads.txt file for AdSense authorization

### DIFF
--- a/public/ads.txt
+++ b/public/ads.txt
@@ -1,0 +1,1 @@
+google.com, pub-2370970936034063, DIRECT, f08c47fec0942fa0


### PR DESCRIPTION
## Summary
- add ads.txt file under public so it is served from the site root
- list the authorized AdSense seller entry provided by the platform

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cbd66d8a30832aa3b1ba29c7281868