### PR TITLE
Adjust AdSense script loading and test mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,15 @@ KBJJF, 스트릿 주짓수, 예거스 등 주요 주최 기관의 대회를 쉽�
 
 ## 기여하기
 오류 제보나 일정 추가는 언제든지 Pull Request로 환영합니다.
+
+### 환경 변수
+Google AdSense 광고를 사용하려면 `.env.local` 파일에 다음 값을 채워주세요.
+
+```
+NEXT_PUBLIC_ADSENSE_CLIENT_ID=ca-pub-xxxxxxxxxxxxxxxx
+NEXT_PUBLIC_ADSENSE_SLOT_ID=xxxxxxxxxx
+```
+
+실제 승인된 광고 단위(`data-ad-slot`)를 입력하지 않으면 광고가 노출되지 않습니다.
+로컬 개발 환경에서는 자동으로 테스트 광고(`data-adtest="on"`)가 요청되므로,
+실제 광고 동작은 프로덕션 도메인에서 확인해주세요.

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,8 @@
 import './globals.css';
 import { Noto_Sans_KR } from 'next/font/google';
 import Link from 'next/link';
+import Script from 'next/script';
+import type { Metadata } from 'next';
 import FancyCursor from '@/components/FancyCursor';
 import CursorToggle from '@/components/CursorToggle';
 import ThemeToggle from '@/components/ThemeToggle';
@@ -10,26 +12,29 @@ const notoSans = Noto_Sans_KR({
   subsets: ['latin'],
 });
 
-export const metadata = {
+const adsenseClientId =
+  process.env.NEXT_PUBLIC_ADSENSE_CLIENT_ID ?? 'ca-pub-2370970936034063';
+
+export const metadata: Metadata = {
   title: 'BJJ 대회 일정',
   description: '주짓수 대회 일정을 한 곳에서!',
+  other: {
+    'google-adsense-account': adsenseClientId,
+  },
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="ko">
-      <head>
-        <meta
-          name="google-adsense-account"
-          content="ca-pub-2370970936034063"
-        />
-        <script
-          async
-          src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-2370970936034063"
-          crossOrigin="anonymous"
-        ></script>
-      </head>
       <body className={notoSans.className}>
+        <Script
+          id="adsbygoogle-init"
+          strategy="afterInteractive"
+          async
+          src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"
+          data-ad-client={adsenseClientId}
+          crossOrigin="anonymous"
+        />
         <FancyCursor />
         <a href="#main" className="skip-link">본문 바로가기</a>
         <header className="header">

--- a/components/AdBanner.tsx
+++ b/components/AdBanner.tsx
@@ -9,24 +9,44 @@ declare global {
 }
 
 export default function AdBanner() {
+  const adClientId =
+    process.env.NEXT_PUBLIC_ADSENSE_CLIENT_ID ?? 'ca-pub-2370970936034063';
+  const adSlotId = process.env.NEXT_PUBLIC_ADSENSE_SLOT_ID ?? '1234567890';
+  const isConfigured = adSlotId && adSlotId !== '1234567890';
+  const shouldUseTestAds = process.env.NODE_ENV !== 'production';
+
   useEffect(() => {
+    if (!isConfigured) {
+      if (process.env.NODE_ENV !== 'production') {
+        console.warn(
+          'Google AdSense 광고 단위(data-ad-slot)가 설정되지 않아 광고가 렌더링되지 않습니다.',
+        );
+      }
+      return;
+    }
+
     try {
       window.adsbygoogle = window.adsbygoogle || [];
       window.adsbygoogle.push({});
     } catch (err) {
       console.error(err);
     }
-  }, []);
+  }, [isConfigured]);
+
+  if (!isConfigured) {
+    return null;
+  }
 
   return (
     <div className="ad-banner">
       <ins
         className="adsbygoogle"
         style={{ display: 'block' }}
-        data-ad-client="ca-pub-2370970936034063"
-        data-ad-slot="1234567890"
+        data-ad-client={adClientId}
+        data-ad-slot={adSlotId}
         data-ad-format="auto"
         data-full-width-responsive="true"
+        {...(shouldUseTestAds ? { 'data-adtest': 'on' } : {})}
       ></ins>
     </div>
   );


### PR DESCRIPTION
## Summary
- load the AdSense bootstrap script with the official `data-ad-client` attribute to avoid console warnings
- request test ad impressions outside production so local development can render AdSense placeholders safely
- document the automatic test-mode behavior for contributors

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d789873888832aa26a80069254b4f2