### PR TITLE
Remove AdSense script/component and add responsive mobile styles for ad banner

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1021,9 +1021,34 @@ img { max-width: 100%; height: auto; display: block; }
 
 
 @media (max-width: 680px) {
+  .header {
+    position: static;
+  }
+
+  .ad-banner {
+    width: min(92vw, 860px);
+    bottom: 12px;
+  }
+
+  .ad-banner__cta {
+    flex-direction: row;
+    min-height: 72px;
+    gap: 12px;
+    padding: 10px 14px;
+  }
+
+  .ad-banner__brand {
+    font-size: 23px;
+    line-height: 1;
+  }
+
+  .ad-banner__text {
+    font-size: 14px;
+    padding: 6px 10px;
+  }
+
   .ad-banner__header {
-    flex-direction: column;
-    align-items: center;
+    width: auto;
   }
 
   .hero-economic-note {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,12 +2,10 @@ import './globals.css';
 import { Noto_Sans_KR } from 'next/font/google';
 import Link from 'next/link';
 import type { Metadata } from 'next';
-import Script from 'next/script';
 import FancyCursor from '@/components/FancyCursor';
 import CursorToggle from '@/components/CursorToggle';
 import ThemeToggle from '@/components/ThemeToggle';
 import AdBanner from '@/components/AdBanner';
-import AdSenseBanner from '@/components/AdSenseBanner';
 
 const notoSans = Noto_Sans_KR({
   subsets: ['latin'],
@@ -21,13 +19,7 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="ko">
-      <head>
-        <Script
-          async
-          src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-2370970936034063"
-          crossOrigin="anonymous"
-        />
-      </head>
+      <head />
       <body className={notoSans.className}>
         <FancyCursor />
         <a href="#main" className="skip-link">본문 바로가기</a>
@@ -48,7 +40,6 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
             <div className="small">© {new Date().getFullYear()} BJJ 대회 정보</div>
           </div>
         </footer>
-        <AdSenseBanner />
         <AdBanner />
       </body>
     </html>


### PR DESCRIPTION
### Motivation
- Remove the external AdSense script and the `AdSenseBanner` component to stop loading the adsense client script from the layout and to simplify ad rendering.
- Improve mobile layout and sizing for the in-app ad banner and related UI so it displays correctly on narrow viewports.

### Description
- Added a mobile `@media (max-width: 680px)` block in `app/globals.css` that sets `.header` to `position: static` and introduces responsive sizing and spacing rules for `.ad-banner`, `.ad-banner__cta`, `.ad-banner__brand`, and `.ad-banner__text`.
- Adjusted `.ad-banner__header` to use `width: auto` on mobile and preserved other compact/card/mobile adjustments already present in the media block.
- Removed the `Script` import and the `<Script>` tag that injected the external AdSense script from `app/layout.tsx`, and removed the `AdSenseBanner` import and its rendering while keeping the in-app `AdBanner` component.
- Simplified the document head in `app/layout.tsx` to an empty `<head />` element while maintaining site metadata and layout structure.

### Testing
- Ran `npm run build` (Next.js production build) and the build completed successfully.
- Ran TypeScript type checking via `tsc --noEmit` and there were no type errors.
- Ran linting via `npm run lint` and the linter passed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd2a5fa830832abf0ba2203c01f9a2)