### PR TITLE
Remove AdSense integration and refine mobile header/ad-banner styles

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1021,9 +1021,62 @@ img { max-width: 100%; height: auto; display: block; }
 
 
 @media (max-width: 680px) {
+  .header {
+    position: static;
+    background: linear-gradient(180deg, rgba(255, 255, 255, 0.95), rgba(255, 255, 255, 0.88));
+    border-bottom: 1px solid rgba(148, 163, 184, 0.22);
+    box-shadow: 0 6px 16px rgba(15, 23, 42, 0.06);
+    backdrop-filter: blur(8px);
+  }
+
+  .header .container {
+    padding: 10px 14px;
+  }
+
+  .nav {
+    min-height: 56px;
+    padding: 0;
+    gap: 10px;
+    justify-content: space-between;
+  }
+
+  .logo {
+    font-size: 20px;
+    font-weight: 700;
+    letter-spacing: -0.4px;
+    line-height: 1.2;
+  }
+
+  .theme-toggle {
+    margin-left: 0;
+    font-size: 12px;
+    padding: 6px 12px;
+  }
+
+  .ad-banner {
+    width: min(92vw, 860px);
+    bottom: 12px;
+  }
+
+  .ad-banner__cta {
+    flex-direction: row;
+    min-height: 72px;
+    gap: 12px;
+    padding: 10px 14px;
+  }
+
+  .ad-banner__brand {
+    font-size: 23px;
+    line-height: 1;
+  }
+
+  .ad-banner__text {
+    font-size: 14px;
+    padding: 6px 10px;
+  }
+
   .ad-banner__header {
-    flex-direction: column;
-    align-items: center;
+    width: auto;
   }
 
   .hero-economic-note {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,12 +2,10 @@ import './globals.css';
 import { Noto_Sans_KR } from 'next/font/google';
 import Link from 'next/link';
 import type { Metadata } from 'next';
-import Script from 'next/script';
 import FancyCursor from '@/components/FancyCursor';
 import CursorToggle from '@/components/CursorToggle';
 import ThemeToggle from '@/components/ThemeToggle';
 import AdBanner from '@/components/AdBanner';
-import AdSenseBanner from '@/components/AdSenseBanner';
 
 const notoSans = Noto_Sans_KR({
   subsets: ['latin'],
@@ -21,13 +19,7 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="ko">
-      <head>
-        <Script
-          async
-          src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-2370970936034063"
-          crossOrigin="anonymous"
-        />
-      </head>
+      <head />
       <body className={notoSans.className}>
         <FancyCursor />
         <a href="#main" className="skip-link">본문 바로가기</a>
@@ -48,7 +40,6 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
             <div className="small">© {new Date().getFullYear()} BJJ 대회 정보</div>
           </div>
         </footer>
-        <AdSenseBanner />
         <AdBanner />
       </body>
     </html>


### PR DESCRIPTION
### Motivation

- Remove the external AdSense script and related component usage to simplify head markup and ad handling.
- Improve mobile layout and visual consistency for the header, navigation, logo, theme toggle, and ad banner under small viewports.
- Make the header non-fixed on small screens and add subtle backdrop/border/shadow for better readability on mobile.

### Description

- Added a set of responsive rules under `@media (max-width: 680px)` in `app/globals.css` to adjust `.header`, `.nav`, `.logo`, `.theme-toggle`, `.ad-banner`, `.ad-banner__cta`, `.ad-banner__brand`, `.ad-banner__text`, and related elements, and changed `.ad-banner__header` width handling.
- Removed the `Script` import and the AdSense script tag from `app/layout.tsx`, removed the `AdSenseBanner` import and its usage, and replaced the previous head content with an empty `<head />` while keeping `AdBanner` in the layout.
- Kept existing UI components like `FancyCursor`, `CursorToggle`, and `ThemeToggle` and preserved the overall layout structure in `app/layout.tsx`.

### Testing

- Ran `next build` to verify the application compiles successfully and the production build completes, and it succeeded.
- Ran the linter via `npm run lint` to ensure code style and basic issues are caught, and it passed.
- Performed a type check with `tsc --noEmit` to ensure TypeScript types remain valid, and it completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd2a5fa830832abf0ba2203c01f9a2)