### PR TITLE
Remove AdSense script and update header positioning and mobile header styles

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -77,8 +77,7 @@ img { max-width: 100%; height: auto; display: block; }
   border-bottom: 1px solid var(--border);
   background: var(--header-bg);
   backdrop-filter: blur(8px);
-  position: sticky;
-  top: 0;
+  position: static;
   z-index: 10;
 }
 .nav { display: flex; gap: 16px; padding: 16px 0; font-weight: 500; align-items: center; }
@@ -1021,9 +1020,62 @@ img { max-width: 100%; height: auto; display: block; }
 
 
 @media (max-width: 680px) {
+  .header {
+    position: static;
+    background: linear-gradient(180deg, rgba(255, 255, 255, 0.95), rgba(255, 255, 255, 0.88));
+    border-bottom: 1px solid rgba(148, 163, 184, 0.22);
+    box-shadow: 0 6px 16px rgba(15, 23, 42, 0.06);
+    backdrop-filter: blur(8px);
+  }
+
+  .header .container {
+    padding: 10px 14px;
+  }
+
+  .nav {
+    min-height: 56px;
+    padding: 0;
+    gap: 10px;
+    justify-content: space-between;
+  }
+
+  .logo {
+    font-size: 20px;
+    font-weight: 700;
+    letter-spacing: -0.4px;
+    line-height: 1.2;
+  }
+
+  .theme-toggle {
+    margin-left: 0;
+    font-size: 12px;
+    padding: 6px 12px;
+  }
+
+  .ad-banner {
+    width: min(92vw, 860px);
+    bottom: 12px;
+  }
+
+  .ad-banner__cta {
+    flex-direction: row;
+    min-height: 72px;
+    gap: 12px;
+    padding: 10px 14px;
+  }
+
+  .ad-banner__brand {
+    font-size: 23px;
+    line-height: 1;
+  }
+
+  .ad-banner__text {
+    font-size: 14px;
+    padding: 6px 10px;
+  }
+
   .ad-banner__header {
-    flex-direction: column;
-    align-items: center;
+    width: auto;
   }
 
   .hero-economic-note {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,12 +2,10 @@ import './globals.css';
 import { Noto_Sans_KR } from 'next/font/google';
 import Link from 'next/link';
 import type { Metadata } from 'next';
-import Script from 'next/script';
 import FancyCursor from '@/components/FancyCursor';
 import CursorToggle from '@/components/CursorToggle';
 import ThemeToggle from '@/components/ThemeToggle';
 import AdBanner from '@/components/AdBanner';
-import AdSenseBanner from '@/components/AdSenseBanner';
 
 const notoSans = Noto_Sans_KR({
   subsets: ['latin'],
@@ -21,13 +19,7 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="ko">
-      <head>
-        <Script
-          async
-          src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-2370970936034063"
-          crossOrigin="anonymous"
-        />
-      </head>
+      <head />
       <body className={notoSans.className}>
         <FancyCursor />
         <a href="#main" className="skip-link">본문 바로가기</a>
@@ -48,7 +40,6 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
             <div className="small">© {new Date().getFullYear()} BJJ 대회 정보</div>
           </div>
         </footer>
-        <AdSenseBanner />
         <AdBanner />
       </body>
     </html>


### PR DESCRIPTION
### Motivation

- Remove the embedded Google AdSense script/component and simplify head rendering to avoid loading the external ad script. 
- Stop using a sticky header to prevent overlap/layout issues and make header positioning stable across viewports. 
- Improve mobile header and ad banner styling for better spacing and readability on small screens.

### Description

- Deleted the `next/script` import and removed the AdSense `<Script>` snippet from `app/layout.tsx`, replaced the explicit head content with an empty `<head />`, and removed the `AdSenseBanner` import and render call while keeping `AdBanner` in place. 
- Changed `.header` from `position: sticky` to `position: static` in `app/globals.css` and added/extended responsive rules under `@media (max-width: 680px)` to refine header background, padding, nav spacing, logo sizing, theme toggle sizing, and ad banner layout. 
- Adjusted `.ad-banner__header` to use `width: auto` and tuned `.ad-banner__cta`, `.ad-banner__brand`, and `.ad-banner__text` styles for mobile. 

### Testing

- Ran a production build with `next build` which completed successfully. 
- Performed a local dev server smoke test (`npm run dev`) to verify layout and responsive behavior, and no runtime type errors were observed. 
- No automated unit tests were modified for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd2a5fa830832abf0ba2203c01f9a2)