### PR TITLE
Improve mobile header and layout styles; remove AdSense script/component

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -77,8 +77,7 @@ img { max-width: 100%; height: auto; display: block; }
   border-bottom: 1px solid var(--border);
   background: var(--header-bg);
   backdrop-filter: blur(8px);
-  position: sticky;
-  top: 0;
+  position: static;
   z-index: 10;
 }
 .nav { display: flex; gap: 16px; padding: 16px 0; font-weight: 500; align-items: center; }
@@ -1021,14 +1020,107 @@ img { max-width: 100%; height: auto; display: block; }
 
 
 @media (max-width: 680px) {
+  body {
+    padding-bottom: 148px;
+  }
+
+  .header {
+    position: static;
+    background: linear-gradient(180deg, rgba(255, 255, 255, 0.95), rgba(255, 255, 255, 0.88));
+    border-bottom: 1px solid rgba(148, 163, 184, 0.22);
+    box-shadow: 0 6px 16px rgba(15, 23, 42, 0.06);
+    backdrop-filter: blur(8px);
+  }
+
+  .header .container {
+    padding: max(10px, env(safe-area-inset-top)) 14px 10px;
+  }
+
+  .nav {
+    min-height: 56px;
+    padding: 0;
+    gap: 10px;
+    justify-content: space-between;
+  }
+
+  .logo {
+    font-size: 18px;
+    font-weight: 700;
+    letter-spacing: -0.4px;
+    line-height: 1.2;
+    white-space: nowrap;
+  }
+
+  .theme-toggle {
+    margin-left: 0;
+    font-size: 12px;
+    padding: 6px 12px;
+  }
+
+  .cursor-toggle {
+    display: none;
+  }
+
+  .ad-banner {
+    width: min(92vw, 860px);
+    bottom: 12px;
+  }
+
+  .ad-banner__cta {
+    flex-direction: row;
+    min-height: 72px;
+    gap: 12px;
+    padding: 10px 14px;
+  }
+
+  .ad-banner__brand {
+    font-size: 23px;
+    line-height: 1;
+  }
+
+  .ad-banner__text {
+    font-size: 14px;
+    padding: 6px 10px;
+  }
+
   .ad-banner__header {
-    flex-direction: column;
-    align-items: center;
+    width: auto;
   }
 
   .hero-economic-note {
     font-size: 11px;
     max-width: 100%;
+  }
+
+  .hero {
+    padding: 52px 16px;
+    margin-bottom: 24px;
+    border-radius: 14px;
+  }
+
+  .hero-title {
+    font-size: clamp(28px, 8vw, 42px);
+    line-height: 1.25;
+  }
+
+  .hero-intro {
+    font-size: 15px;
+    line-height: 1.55;
+  }
+
+  .hero .actions {
+    width: 100%;
+    max-width: 460px;
+    margin: 18px auto 0;
+    gap: 10px;
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .hero .actions .btn {
+    width: 100%;
+    text-align: center;
+    padding: 10px 12px;
   }
 
   .business-compact {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,12 +2,10 @@ import './globals.css';
 import { Noto_Sans_KR } from 'next/font/google';
 import Link from 'next/link';
 import type { Metadata } from 'next';
-import Script from 'next/script';
 import FancyCursor from '@/components/FancyCursor';
 import CursorToggle from '@/components/CursorToggle';
 import ThemeToggle from '@/components/ThemeToggle';
 import AdBanner from '@/components/AdBanner';
-import AdSenseBanner from '@/components/AdSenseBanner';
 
 const notoSans = Noto_Sans_KR({
   subsets: ['latin'],
@@ -21,13 +19,7 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="ko">
-      <head>
-        <Script
-          async
-          src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-2370970936034063"
-          crossOrigin="anonymous"
-        />
-      </head>
+      <head />
       <body className={notoSans.className}>
         <FancyCursor />
         <a href="#main" className="skip-link">본문 바로가기</a>
@@ -48,7 +40,6 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
             <div className="small">© {new Date().getFullYear()} BJJ 대회 정보</div>
           </div>
         </footer>
-        <AdSenseBanner />
         <AdBanner />
       </body>
     </html>


### PR DESCRIPTION
### Motivation
- Improve the mobile experience by turning the header static, adding safe-area and spacing adjustments, and tuning hero/ad layouts for small screens.
- Simplify ad integration by removing the embedded AdSense script and the `AdSenseBanner` component from the global layout.

### Description
- Reworked `app/globals.css` to make `.header` static and added a comprehensive `@media (max-width: 680px)` block that adjusts body padding, header background, container safe-area padding, nav sizing, logo typography, theme/cursor toggle behavior, ad-banner layout, and hero spacing and button grid.
- Consolidated earlier sticky-to-static header change to remove sticky positioning at the top level, and added mobile-specific visual tweaks like gradient background, border, and shadow for the header.
- Modified ad-banner styles to fit small viewports and updated `.ad-banner__header` to use `width: auto` instead of column/center layout.
- Updated `app/layout.tsx` to remove the `next/script` ad script injection and the `AdSenseBanner` import/usage, leaving an empty `<head />` and keeping `AdBanner`, `ThemeToggle`, `CursorToggle`, and `FancyCursor` intact.

### Testing
- Ran `next build` (production build) and TypeScript type-checking, and the build completed successfully.
- Ran `npm run lint` to catch style/format issues and it passed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd2a5fa830832abf0ba2203c01f9a2)