### PR TITLE
Responsive/mobile improvements for Events list, UI tweaks, and remove AdSense script

### DIFF
--- a/app/events/EventsList.tsx
+++ b/app/events/EventsList.tsx
@@ -43,6 +43,18 @@ export default function EventsList({
   const month = searchParams.get('month') || '';
   const showPast = searchParams.get('past') === '1';
   const [query, setQuery] = useState('');
+  const [isMobile, setIsMobile] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    const media = window.matchMedia('(max-width: 680px)');
+    const apply = () => setIsMobile(media.matches);
+    apply();
+
+    media.addEventListener('change', apply);
+    return () => media.removeEventListener('change', apply);
+  }, []);
 
   /**
    * 탭(태그) 목록은 이벤트에 등장한 태그를 기반으로 생성한다.
@@ -77,10 +89,12 @@ export default function EventsList({
    * 3) 월 선택
    * 4) 검색어 (월/텍스트 모두 지원)
    */
+  const effectiveShowPast = isMobile ? false : showPast;
+
   const dateFiltered = useMemo(
     () =>
-      showPast ? events : events.filter(e => new Date(e.date) >= today),
-    [events, showPast, today],
+      effectiveShowPast ? events : events.filter(e => new Date(e.date) >= today),
+    [effectiveShowPast, events, today],
   );
 
   const regionFiltered = useMemo(
@@ -129,18 +143,20 @@ export default function EventsList({
   );
 
   const currentIndex = useMemo(
-    () => Math.max(0, tabsWithData.findIndex(t => t.key === tag)),
-    [tabsWithData, tag],
+    () => Math.max(0, tabsWithData.findIndex(t => t.key === (isMobile ? undefined : tag))),
+    [isMobile, tabsWithData, tag],
   );
 
   useEffect(() => {
+    if (isMobile) return;
+
     if (tag && !tabsWithData.some(t => t.key === tag)) {
       const params = new URLSearchParams(Array.from(searchParams.entries()));
       params.delete('tag');
       const queryString = params.toString();
       router.push(`${basePath}${queryString ? `?${queryString}` : ''}`);
     }
-  }, [basePath, router, searchParams, tag, tabsWithData]);
+  }, [basePath, isMobile, router, searchParams, tag, tabsWithData]);
 
   /** 기본으로 노출할 탭 수 (이후에는 더보기/접기 버튼으로 토글). */
   const SHOW_LIMIT = 6;
@@ -193,14 +209,16 @@ export default function EventsList({
   }, []);
 
   const items = useMemo(() => {
-    const pool = tag ? searchFiltered.filter(e => e.tags?.includes(tag)) : searchFiltered;
+    const pool = !isMobile && tag
+      ? searchFiltered.filter(e => e.tags?.includes(tag))
+      : searchFiltered;
     return [...pool].sort((a, b) => {
       if (!a.date && !b.date) return 0;
       if (!a.date) return 1;
       if (!b.date) return -1;
       return a.date.localeCompare(b.date);
     });
-  }, [searchFiltered, tag]);
+  }, [isMobile, searchFiltered, tag]);
 
   const updateSearchParam = useCallback(
     (key: string, value: string | undefined) => {
@@ -274,73 +292,77 @@ export default function EventsList({
           available={dateFiltered}
           basePath={basePath}
         />
-        <label className="past-toggle">
-          <input
-            type="checkbox"
-            checked={showPast}
-            onChange={e => togglePast(e.target.checked)}
-          />
-          <span className="switch" aria-hidden="true"></span>
-          <span>날짜 지난 시합 일정도 보기</span>
-        </label>
+        {!isMobile && (
+          <label className="past-toggle">
+            <input
+              type="checkbox"
+              checked={showPast}
+              onChange={e => togglePast(e.target.checked)}
+            />
+            <span className="switch" aria-hidden="true"></span>
+            <span>날짜 지난 시합 일정도 보기</span>
+          </label>
+        )}
       </div>
 
       {/* 태그 탭 목록 */}
-      <div className="tabs-wrapper">
-        <button
-          className="tab-scroll left"
-          onClick={() => scrollTabs(-1)}
-          disabled={!canScrollLeft}
-          aria-label="이전 탭"
-        >
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-            <path d="M15 6l-6 6 6 6" />
-          </svg>
-        </button>
-        <div className="tabs" role="tablist" ref={tabsContainerRef}>
-          {visibleTabs.map(({ key, label, idx, count }) => (
-            key === '__more' || key === '__less' ? (
-              <button
-                key={key}
-                className="tab"
-                onClick={() => setShowAllTabs(key === '__more')}
-              >
-                {label}
-              </button>
-            ) : (
-              <button
-                key={key ?? 'all'}
-                ref={el => {
-                  if (idx >= 0) {
-                    tabRefs.current[idx] = el;
-                  }
-                }}
-                role="tab"
-                aria-selected={idx === currentIndex}
-                tabIndex={idx === currentIndex ? 0 : -1}
-                className={`tab${idx === currentIndex ? ' active' : ''}`}
-                onClick={() => selectTab(idx)}
-                onKeyDown={e => handleKeyDown(e, idx)}
-              >
-                {label}
-                {typeof count === 'number' && (
-                  <span className="tab-count">{count}</span>
-                )}
-              </button>
-            )
-          ))}
+      {!isMobile && (
+        <div className="tabs-wrapper">
+          <button
+            className="tab-scroll left"
+            onClick={() => scrollTabs(-1)}
+            disabled={!canScrollLeft}
+            aria-label="이전 탭"
+          >
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <path d="M15 6l-6 6 6 6" />
+            </svg>
+          </button>
+          <div className="tabs" role="tablist" ref={tabsContainerRef}>
+            {visibleTabs.map(({ key, label, idx, count }) => (
+              key === '__more' || key === '__less' ? (
+                <button
+                  key={key}
+                  className="tab"
+                  onClick={() => setShowAllTabs(key === '__more')}
+                >
+                  {label}
+                </button>
+              ) : (
+                <button
+                  key={key ?? 'all'}
+                  ref={el => {
+                    if (idx >= 0) {
+                      tabRefs.current[idx] = el;
+                    }
+                  }}
+                  role="tab"
+                  aria-selected={idx === currentIndex}
+                  tabIndex={idx === currentIndex ? 0 : -1}
+                  className={`tab${idx === currentIndex ? ' active' : ''}`}
+                  onClick={() => selectTab(idx)}
+                  onKeyDown={e => handleKeyDown(e, idx)}
+                >
+                  {label}
+                  {typeof count === 'number' && (
+                    <span className="tab-count">{count}</span>
+                  )}
+                </button>
+              )
+            ))}
+          </div>
+          <button
+            className="tab-scroll right"
+            onClick={() => scrollTabs(1)}
+            disabled={!canScrollRight}
+            aria-label="다음 탭"
+          >
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <path d="M9 18l6-6-6-6" />
+            </svg>
+          </button>
         </div>
-        <button
-          className="tab-scroll right"
-          onClick={() => scrollTabs(1)}
-          disabled={!canScrollRight}
-          aria-label="다음 탭"
-        >
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-            <path d="M9 18l6-6-6-6" />
-          </svg>
-        </button>
-      </div>
+      )}
 
       {/* 대회 카드 목록 */}
       <div className="grid">

--- a/app/globals.css
+++ b/app/globals.css
@@ -77,8 +77,7 @@ img { max-width: 100%; height: auto; display: block; }
   border-bottom: 1px solid var(--border);
   background: var(--header-bg);
   backdrop-filter: blur(8px);
-  position: sticky;
-  top: 0;
+  position: static;
   z-index: 10;
 }
 .nav { display: flex; gap: 16px; padding: 16px 0; font-weight: 500; align-items: center; }
@@ -1021,14 +1020,107 @@ img { max-width: 100%; height: auto; display: block; }
 
 
 @media (max-width: 680px) {
+  body {
+    padding-bottom: 148px;
+  }
+
+  .header {
+    position: static;
+    background: linear-gradient(180deg, rgba(255, 255, 255, 0.95), rgba(255, 255, 255, 0.88));
+    border-bottom: 1px solid rgba(148, 163, 184, 0.22);
+    box-shadow: 0 6px 16px rgba(15, 23, 42, 0.06);
+    backdrop-filter: blur(8px);
+  }
+
+  .header .container {
+    padding: max(10px, env(safe-area-inset-top)) 14px 10px;
+  }
+
+  .nav {
+    min-height: 56px;
+    padding: 0;
+    gap: 10px;
+    justify-content: space-between;
+  }
+
+  .logo {
+    font-size: 18px;
+    font-weight: 700;
+    letter-spacing: -0.4px;
+    line-height: 1.2;
+    white-space: nowrap;
+  }
+
+  .theme-toggle {
+    margin-left: 0;
+    font-size: 12px;
+    padding: 6px 12px;
+  }
+
+  .cursor-toggle {
+    display: none;
+  }
+
+  .ad-banner {
+    width: min(92vw, 860px);
+    bottom: 12px;
+  }
+
+  .ad-banner__cta {
+    flex-direction: row;
+    min-height: 72px;
+    gap: 12px;
+    padding: 10px 14px;
+  }
+
+  .ad-banner__brand {
+    font-size: 23px;
+    line-height: 1;
+  }
+
+  .ad-banner__text {
+    font-size: 14px;
+    padding: 6px 10px;
+  }
+
   .ad-banner__header {
-    flex-direction: column;
-    align-items: center;
+    width: auto;
   }
 
   .hero-economic-note {
     font-size: 11px;
     max-width: 100%;
+  }
+
+  .hero {
+    padding: 52px 16px;
+    margin-bottom: 24px;
+    border-radius: 14px;
+  }
+
+  .hero-title {
+    font-size: clamp(28px, 8vw, 42px);
+    line-height: 1.25;
+  }
+
+  .hero-intro {
+    font-size: 15px;
+    line-height: 1.55;
+  }
+
+  .hero .actions {
+    width: 100%;
+    max-width: 460px;
+    margin: 18px auto 0;
+    gap: 10px;
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .hero .actions .btn {
+    width: 100%;
+    text-align: center;
+    padding: 10px 12px;
   }
 
   .business-compact {
@@ -1060,6 +1152,25 @@ img { max-width: 100%; height: auto; display: block; }
 
   .card-tags {
     justify-content: flex-start;
+  }
+
+  .filters .month-filter {
+    width: 100%;
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    padding-bottom: 4px;
+    gap: 6px;
+    scrollbar-width: none;
+  }
+
+  .filters .month-filter::-webkit-scrollbar {
+    display: none;
+  }
+
+  .filters .month-filter .month-option {
+    flex: 0 0 auto;
+    white-space: nowrap;
   }
 
   .august-highlight-media {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,12 +2,10 @@ import './globals.css';
 import { Noto_Sans_KR } from 'next/font/google';
 import Link from 'next/link';
 import type { Metadata } from 'next';
-import Script from 'next/script';
 import FancyCursor from '@/components/FancyCursor';
 import CursorToggle from '@/components/CursorToggle';
 import ThemeToggle from '@/components/ThemeToggle';
 import AdBanner from '@/components/AdBanner';
-import AdSenseBanner from '@/components/AdSenseBanner';
 
 const notoSans = Noto_Sans_KR({
   subsets: ['latin'],
@@ -21,13 +19,7 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="ko">
-      <head>
-        <Script
-          async
-          src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-2370970936034063"
-          crossOrigin="anonymous"
-        />
-      </head>
+      <head />
       <body className={notoSans.className}>
         <FancyCursor />
         <a href="#main" className="skip-link">본문 바로가기</a>
@@ -48,7 +40,6 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
             <div className="small">© {new Date().getFullYear()} BJJ 대회 정보</div>
           </div>
         </footer>
-        <AdSenseBanner />
         <AdBanner />
       </body>
     </html>


### PR DESCRIPTION
### Motivation
- Improve usability on small screens by simplifying the Events list UI and preventing desktop-only filters/tabs from interfering with mobile UX.
- Adjust global styles for better mobile header and hero presentation and ensure adequate bottom spacing for fixed elements.
- Remove the AdSense script and banner integration from the root layout.

### Description
- Add `isMobile` media-query detection in `EventsList.tsx` and disable tag-based tab filtering and the "show past" toggle when on small screens, and prevent invalid tag params from redirecting on mobile. 
- Hide the tabs bar and the past-toggle control on mobile, and adapt the items pool and `currentIndex` computation to treat tags as inactive on mobile. 
- Update `globals.css` with mobile-specific rules: add bottom padding for the body, change header positioning and styling for small screens, adjust hero, ad-banner, filters month scroller, and several card/layout tweaks.
- Remove AdSense-related code by deleting the script injection and `AdSenseBanner` import/use from `layout.tsx`.

### Testing
- Performed a production build with `next build` which completed successfully.
- Ran TypeScript checks with `tsc --noEmit` and the type check passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd2a5fa830832abf0ba2203c01f9a2)